### PR TITLE
Preparator: SplitProperty

### DIFF
--- a/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/define/SplitProperty.scala
+++ b/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/define/SplitProperty.scala
@@ -4,10 +4,12 @@ import java.util
 
 import de.hpi.isg.dataprep.components.Preparator
 import de.hpi.isg.dataprep.exceptions.ParameterNotSpecifiedException
+import de.hpi.isg.dataprep.metadata.PropertyDataType
 import de.hpi.isg.dataprep.model.target.objects.Metadata
 import de.hpi.isg.dataprep.preparators.implementation.DefaultSplitPropertyImpl
+import de.hpi.isg.dataprep.util.DataType
 
-class SplitProperty(val propertyName: String, val separator: Char) extends Preparator{
+class SplitProperty(val propertyName: String, val separator: Char, fromLeft: Boolean, times: Int) extends Preparator{
 
     impl = new DefaultSplitPropertyImpl
 
@@ -20,5 +22,10 @@ class SplitProperty(val propertyName: String, val separator: Char) extends Prepa
   override def buildMetadataSetup(): Unit = {
     val prerequisites = new util.ArrayList[Metadata]
     if (propertyName == null) throw new ParameterNotSpecifiedException(String.format("%s not specified.", propertyName))
+
+    if (times > 0) throw new IllegalArgumentException("Times must be greater than 0.")
+    prerequisites.add(new PropertyDataType(propertyName, DataType.PropertyType.STRING))
+
+    this.prerequisites.addAll(prerequisites)
   }
 }

--- a/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/define/SplitProperty.scala
+++ b/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/define/SplitProperty.scala
@@ -1,0 +1,24 @@
+package de.hpi.isg.dataprep.preparators.define
+
+import java.util
+
+import de.hpi.isg.dataprep.components.Preparator
+import de.hpi.isg.dataprep.exceptions.ParameterNotSpecifiedException
+import de.hpi.isg.dataprep.model.target.objects.Metadata
+import de.hpi.isg.dataprep.preparators.implementation.DefaultSplitPropertyImpl
+
+class SplitProperty(val propertyName: String, val separator: Char) extends Preparator{
+
+    impl = new DefaultSplitPropertyImpl
+
+  /**
+    * This method validates the input parameters of a {@link AbstractPreparator}. If succeeds, setup the values of metadata into both
+    * prerequisite and toChange set.
+    *
+    * @throws ParameterNotSpecifiedException
+    */
+  override def buildMetadataSetup(): Unit = {
+    val prerequisites = new util.ArrayList[Metadata]
+    if (propertyName == null) throw new ParameterNotSpecifiedException(String.format("%s not specified.", propertyName))
+  }
+}

--- a/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/define/SplitProperty.scala
+++ b/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/define/SplitProperty.scala
@@ -9,7 +9,7 @@ import de.hpi.isg.dataprep.model.target.objects.Metadata
 import de.hpi.isg.dataprep.preparators.implementation.DefaultSplitPropertyImpl
 import de.hpi.isg.dataprep.util.DataType
 
-class SplitProperty(val propertyName: String, val separator: Char, fromLeft: Boolean, times: Int) extends Preparator{
+class SplitProperty(val propertyName: String, val separator: Char, val fromLeft: Boolean, val times: Int) extends Preparator{
 
     impl = new DefaultSplitPropertyImpl
 
@@ -23,7 +23,7 @@ class SplitProperty(val propertyName: String, val separator: Char, fromLeft: Boo
     val prerequisites = new util.ArrayList[Metadata]
     if (propertyName == null) throw new ParameterNotSpecifiedException(String.format("%s not specified.", propertyName))
 
-    if (times > 0) throw new IllegalArgumentException("Times must be greater than 0.")
+    if (times <= 0) throw new IllegalArgumentException("Times must be greater than 0.")
     prerequisites.add(new PropertyDataType(propertyName, DataType.PropertyType.STRING))
 
     this.prerequisites.addAll(prerequisites)

--- a/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/define/SplitProperty.scala
+++ b/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/define/SplitProperty.scala
@@ -10,7 +10,7 @@ import de.hpi.isg.dataprep.preparators.implementation.DefaultSplitPropertyImpl
 import de.hpi.isg.dataprep.util.DataType
 
 
-class SplitProperty(val propertyName: String, val separator: String, val fromLeft: Boolean = true, val times: Option[Int]) extends Preparator{
+class SplitProperty(val propertyName: String, val separator: Option[String], val fromLeft: Boolean = true, val times: Option[Int]) extends Preparator{
 
     impl = new DefaultSplitPropertyImpl
 

--- a/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/define/SplitProperty.scala
+++ b/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/define/SplitProperty.scala
@@ -9,7 +9,8 @@ import de.hpi.isg.dataprep.model.target.objects.Metadata
 import de.hpi.isg.dataprep.preparators.implementation.DefaultSplitPropertyImpl
 import de.hpi.isg.dataprep.util.DataType
 
-class SplitProperty(val propertyName: String, val separator: Char, val fromLeft: Boolean, val times: Int) extends Preparator{
+
+class SplitProperty(val propertyName: String, val separator: String, val fromLeft: Boolean, val times: Int) extends Preparator{
 
     impl = new DefaultSplitPropertyImpl
 

--- a/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/define/SplitProperty.scala
+++ b/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/define/SplitProperty.scala
@@ -10,7 +10,7 @@ import de.hpi.isg.dataprep.preparators.implementation.DefaultSplitPropertyImpl
 import de.hpi.isg.dataprep.util.DataType
 
 
-class SplitProperty(val propertyName: String, val separator: String, val fromLeft: Boolean, val times: Int) extends Preparator{
+class SplitProperty(val propertyName: String, val separator: String, val fromLeft: Boolean = true, val times: Option[Int]) extends Preparator{
 
     impl = new DefaultSplitPropertyImpl
 
@@ -24,7 +24,12 @@ class SplitProperty(val propertyName: String, val separator: String, val fromLef
     val prerequisites = new util.ArrayList[Metadata]
     if (propertyName == null) throw new ParameterNotSpecifiedException(String.format("%s not specified.", propertyName))
 
-    if (times <= 0) throw new IllegalArgumentException("Times must be greater than 0.")
+    times match {
+      case Some(t) => {
+        if (t <= 1) throw new IllegalArgumentException("Times must be greater than 1 in order to split a column.")
+      }
+      case _ =>
+    }
     prerequisites.add(new PropertyDataType(propertyName, DataType.PropertyType.STRING))
 
     this.prerequisites.addAll(prerequisites)

--- a/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/define/SplitProperty.scala
+++ b/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/define/SplitProperty.scala
@@ -1,37 +1,36 @@
 package de.hpi.isg.dataprep.preparators.define
 
-import java.util
-
 import de.hpi.isg.dataprep.components.Preparator
 import de.hpi.isg.dataprep.exceptions.ParameterNotSpecifiedException
 import de.hpi.isg.dataprep.metadata.PropertyDataType
-import de.hpi.isg.dataprep.model.target.objects.Metadata
 import de.hpi.isg.dataprep.preparators.implementation.DefaultSplitPropertyImpl
 import de.hpi.isg.dataprep.util.DataType
 
 
-class SplitProperty(val propertyName: String, val separator: Option[String], val fromLeft: Boolean = true, val times: Option[Int]) extends Preparator{
+class SplitProperty(val propertyName: String, val separator: Option[String], val numCols: Option[Int], val fromLeft: Boolean) extends Preparator{
+  impl = new DefaultSplitPropertyImpl
 
-    impl = new DefaultSplitPropertyImpl
+  def this(propertyName: String, separator: String, numCols: Int, fromLeft: Boolean = true) {
+    this(propertyName, Some(separator), Some(numCols), fromLeft)
+  }
 
-  /**
-    * This method validates the input parameters of a {@link AbstractPreparator}. If succeeds, setup the values of metadata into both
-    * prerequisite and toChange set.
-    *
-    * @throws ParameterNotSpecifiedException
-    */
+  def this(propertyName: String, separator: String) {
+    this(propertyName, Some(separator), None, true)
+  }
+
+  def this(propertyName: String) {
+    this(propertyName, None, None, true)
+  }
+
   override def buildMetadataSetup(): Unit = {
-    val prerequisites = new util.ArrayList[Metadata]
     if (propertyName == null) throw new ParameterNotSpecifiedException(String.format("%s not specified.", propertyName))
 
-    times match {
-      case Some(t) => {
-        if (t <= 1) throw new IllegalArgumentException("Times must be greater than 1 in order to split a column.")
-      }
+    numCols match {
+      case Some(n) =>
+        if (n <= 1) throw new IllegalArgumentException("numCols must be greater than 1 in order to split a column.")
       case _ =>
     }
-    prerequisites.add(new PropertyDataType(propertyName, DataType.PropertyType.STRING))
 
-    this.prerequisites.addAll(prerequisites)
+    this.prerequisites.add(new PropertyDataType(propertyName, DataType.PropertyType.STRING))
   }
 }

--- a/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/implementation/DefaultSplitPropertyImpl.scala
+++ b/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/implementation/DefaultSplitPropertyImpl.scala
@@ -95,9 +95,7 @@ class DefaultSplitPropertyImpl extends PreparatorImpl {
     if (!dataFrame.columns.contains(propertyName))
       throw new IllegalArgumentException(s"No column $propertyName found!")
 
-    implicit val rowEncoder: Encoder[Row] = RowEncoder(appendEmptyColumns(dataFrame, propertyName, times).schema)
-
-    val splitValue = (value: String) => {
+    def splitValue(value: String): Seq[String] = {
       var split = value.split(separator)
       if (!fromLeft)
         split = split.reverse
@@ -115,6 +113,7 @@ class DefaultSplitPropertyImpl extends PreparatorImpl {
       head :+ tail.mkString(separator)
     }
 
+    val rowEncoder: Encoder[Row] = RowEncoder(appendEmptyColumns(dataFrame, propertyName, times).schema)
     dataFrame.map(
       row => {
         val index = row.fieldIndex(propertyName)
@@ -122,7 +121,7 @@ class DefaultSplitPropertyImpl extends PreparatorImpl {
         val split = splitValue(value)
         Row.fromSeq(row.toSeq ++ split)
       }
-    )
+    )(rowEncoder)
   }
 
   def appendEmptyColumns(dataFrame: Dataset[Row], propertyName: String, numCols: Int): Dataset[Row] = {

--- a/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/implementation/DefaultSplitPropertyImpl.scala
+++ b/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/implementation/DefaultSplitPropertyImpl.scala
@@ -95,7 +95,7 @@ class DefaultSplitPropertyImpl extends PreparatorImpl {
     if (!dataFrame.columns.contains(propertyName))
       throw new IllegalArgumentException(s"No column $propertyName found!")
 
-    def splitValue(value: String): Seq[String] = {
+    val splitValue = (value: String) => {
       var split = value.split(separator)
       if (!fromLeft)
         split = split.reverse

--- a/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/implementation/DefaultSplitPropertyImpl.scala
+++ b/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/implementation/DefaultSplitPropertyImpl.scala
@@ -92,6 +92,9 @@ class DefaultSplitPropertyImpl extends PreparatorImpl {
   }
 
   def createSplitValuesDataFrame(dataFrame: Dataset[Row], propertyName: String, separator: String, times: Int, fromLeft: Boolean): Dataset[Row] = {
+    if (!dataFrame.columns.contains(propertyName))
+      throw new IllegalArgumentException(s"No column $propertyName found!")
+
     implicit val rowEncoder: Encoder[Row] = RowEncoder(appendEmptyColumns(dataFrame, propertyName, times).schema)
 
     val splitValue = (value: String) => {

--- a/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/implementation/DefaultSplitPropertyImpl.scala
+++ b/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/implementation/DefaultSplitPropertyImpl.scala
@@ -1,0 +1,22 @@
+package de.hpi.isg.dataprep.preparators.implementation
+
+import de.hpi.isg.dataprep.ExecutionContext
+import de.hpi.isg.dataprep.components.PreparatorImpl
+import de.hpi.isg.dataprep.model.error.PreparationError
+import de.hpi.isg.dataprep.model.target.system.AbstractPreparator
+import de.hpi.isg.dataprep.preparators.define.SplitProperty
+import org.apache.spark.sql.{Dataset, Row}
+import org.apache.spark.util.CollectionAccumulator
+
+class DefaultSplitPropertyImpl extends PreparatorImpl {
+
+  override def executeLogic(abstractPreparator: AbstractPreparator, dataFrame: Dataset[Row], errorAccumulator: CollectionAccumulator[PreparationError]): ExecutionContext = {
+    val preparator = abstractPreparator.asInstanceOf[SplitProperty]
+    val propertyName = preparator.propertyName
+    val separator = preparator.separator
+
+    val resultDataFrame = dataFrame
+
+    new ExecutionContext(resultDataFrame, errorAccumulator)
+  }
+}

--- a/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/implementation/DefaultSplitPropertyImpl.scala
+++ b/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/implementation/DefaultSplitPropertyImpl.scala
@@ -22,6 +22,8 @@ class DefaultSplitPropertyImpl extends PreparatorImpl {
     if (!dataFrame.columns.contains(propertyName))
       throw new IllegalArgumentException(s"dataFrame has no column $propertyName")
 
+    val bla = findMaxSeperatorCount(dataFrame, propertyName, separator)
+
     if (times < 2)
       return new ExecutionContext(dataFrame, errorAccumulator)
 
@@ -68,5 +70,18 @@ class DefaultSplitPropertyImpl extends PreparatorImpl {
         Row.fromSeq(row.toSeq ++ split)
       }
     )(rowEncoder)
+  }
+
+  def findMaxSeperatorCount(dataSet: Dataset[Row], propertyName: String, separator: String): Int = {
+    val test = dataSet
+      .select(propertyName)
+      .collect()
+      .map(row => {
+        val operatedValue: String = row.getAs[String](0)
+        println("Test")
+        operatedValue.count(_ == separator)
+      })
+
+    1
   }
 }

--- a/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/implementation/DefaultSplitPropertyImpl.scala
+++ b/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/implementation/DefaultSplitPropertyImpl.scala
@@ -1,13 +1,16 @@
 package de.hpi.isg.dataprep.preparators.implementation
 
-import de.hpi.isg.dataprep.ExecutionContext
+import de.hpi.isg.dataprep.{ConversionHelper, ExecutionContext}
 import de.hpi.isg.dataprep.components.PreparatorImpl
-import de.hpi.isg.dataprep.model.error.PreparationError
+import de.hpi.isg.dataprep.model.error.{PreparationError, RecordError}
 import de.hpi.isg.dataprep.model.target.system.AbstractPreparator
 import de.hpi.isg.dataprep.preparators.define.SplitProperty
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.{Dataset, Row}
 import org.apache.spark.util.CollectionAccumulator
+import org.apache.spark.sql.functions.lit
+
+import scala.util.{Failure, Success, Try}
 
 import scala.util.Try
 
@@ -18,16 +21,51 @@ class DefaultSplitPropertyImpl extends PreparatorImpl {
     val propertyName = preparator.propertyName
     val separator = preparator.separator
     val fromLeft = preparator.fromLeft
+    val times = preparator.times
 
-    val rowEncoder = RowEncoder(dataFrame.schema)
-    val resultDataFrame = dataFrame
-    dataFrame.flatMap(row => {
-      val x = Try{
-        row
-      }
-      x.toOption
-    })(rowEncoder)
+    var resultDataFrame = dataFrame
+
+    for (i <- 0 to times) {
+      resultDataFrame = resultDataFrame.withColumn(s"split $i", lit(""))
+    }
 
     new ExecutionContext(resultDataFrame, errorAccumulator)
+
+    val rowEncoder = RowEncoder(dataFrame.schema)
+
+    val createdDataset = dataFrame.flatMap(row => {
+      val indexTry = Try {
+        row.fieldIndex(propertyName)
+      }
+      val index = indexTry match {
+        case Failure(content) => {
+          throw content
+        }
+        case Success(content) => {
+          content
+        }
+      }
+      val operatedValue = row.getAs[String](index)
+
+      val splittedValues = operatedValue.split(separator, times+1)
+
+      val tryConvert = Try {
+        val newSeq = splittedValues
+        val newRow = Row.fromSeq(newSeq)
+        newRow
+      }
+      val convertOption = tryConvert match {
+        case Failure(content) => {
+          errorAccumulator.add(new RecordError(operatedValue, content))
+          tryConvert
+        }
+        case Success(content) => tryConvert
+      }
+      convertOption.toOption
+    })(rowEncoder)
+
+    createdDataset.count()
+
+    new ExecutionContext(createdDataset, errorAccumulator)
   }
 }

--- a/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/implementation/DefaultSplitPropertyImpl.scala
+++ b/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/implementation/DefaultSplitPropertyImpl.scala
@@ -5,8 +5,11 @@ import de.hpi.isg.dataprep.components.PreparatorImpl
 import de.hpi.isg.dataprep.model.error.PreparationError
 import de.hpi.isg.dataprep.model.target.system.AbstractPreparator
 import de.hpi.isg.dataprep.preparators.define.SplitProperty
+import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.{Dataset, Row}
 import org.apache.spark.util.CollectionAccumulator
+
+import scala.util.Try
 
 class DefaultSplitPropertyImpl extends PreparatorImpl {
 
@@ -14,8 +17,16 @@ class DefaultSplitPropertyImpl extends PreparatorImpl {
     val preparator = abstractPreparator.asInstanceOf[SplitProperty]
     val propertyName = preparator.propertyName
     val separator = preparator.separator
+    val fromLeft = preparator.fromLeft
 
+    val rowEncoder = RowEncoder(dataFrame.schema)
     val resultDataFrame = dataFrame
+    dataFrame.flatMap(row => {
+      val x = Try{
+        row
+      }
+      x.toOption
+    })(rowEncoder)
 
     new ExecutionContext(resultDataFrame, errorAccumulator)
   }

--- a/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/implementation/DefaultSplitPropertyImpl.scala
+++ b/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/implementation/DefaultSplitPropertyImpl.scala
@@ -2,7 +2,7 @@ package de.hpi.isg.dataprep.preparators.implementation
 
 import de.hpi.isg.dataprep.ExecutionContext
 import de.hpi.isg.dataprep.components.PreparatorImpl
-import de.hpi.isg.dataprep.model.error.PreparationError
+import de.hpi.isg.dataprep.model.error.{PreparationError, RecordError}
 import de.hpi.isg.dataprep.model.target.system.AbstractPreparator
 import de.hpi.isg.dataprep.preparators.define.SplitProperty
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
@@ -15,39 +15,83 @@ class DefaultSplitPropertyImpl extends PreparatorImpl {
   override def executeLogic(abstractPreparator: AbstractPreparator, dataFrame: Dataset[Row], errorAccumulator: CollectionAccumulator[PreparationError]): ExecutionContext = {
     val preparator = abstractPreparator.asInstanceOf[SplitProperty]
     val propertyName = preparator.propertyName
-    val fromLeft = preparator.fromLeft
 
-    if (!dataFrame.columns.contains(propertyName))
-      throw new IllegalArgumentException(s"dataFrame has no column $propertyName")
+    val (separator, numCols): (String, Int) = try {
+      val separator = preparator.separator match {
+        case Some(s) => s
+        case _ => findSeperator(dataFrame, propertyName)
+      }
 
-    val separator = preparator.separator match {
-      case null => findSeperator(dataFrame, propertyName)
-      case Some(s) => s
+      val numCols = preparator.numCols match {
+        case Some(n) => n
+        case _ => findNumberOfColumns(dataFrame, propertyName, separator)
+      }
+
+      (separator, numCols)
+    } catch {
+      case e: IllegalArgumentException =>
+        errorAccumulator.add(new RecordError(propertyName, e))
+        return new ExecutionContext(dataFrame, errorAccumulator)
     }
 
-    val times = preparator.times match {
-      case null => findMaxSeperatorCount(dataFrame, propertyName, separator)
-      case Some(t) => t
-    }
-
-    if (times < 2)
-      return new ExecutionContext(dataFrame, errorAccumulator)
-
-    val splitValuesDataFrame = createSplitValuesDataFrame(dataFrame, propertyName, separator, fromLeft, times)
+    val splitValuesDataFrame = createSplitValuesDataFrame(
+      dataFrame,
+      propertyName,
+      separator,
+      numCols,
+      preparator.fromLeft
+    )
 
     splitValuesDataFrame.count()
     new ExecutionContext(splitValuesDataFrame, errorAccumulator)
   }
 
-  def appendEmptyColumns(dataFrame: Dataset[Row], propertyName: String, n: Int): Dataset[Row] = {
-    var result = dataFrame
-    for (i <- 1 to n) {
-      result = result.withColumn(s"$propertyName$i", lit(""))
+  def findSeperator(dataFrame: Dataset[Row], propertyName: String): String = {
+    // Given a column name, this method returns the character that is most likely the separator.
+    // Possible separators are non-alphanumeric characters that are evenly distributed over all rows.
+    // Rows where the character does not appear at all are ignored.
+    // If multiple characters fulfill this condition, the most common character is selected.
+
+    if (!dataFrame.columns.contains(propertyName))
+      throw new IllegalArgumentException(s"No column $propertyName found!")
+
+    val charMaps = dataFrame.select(propertyName).collect().map(
+      row => {
+        val value = row.getAs[String](0)
+        value.groupBy(identity).filter{
+          case(char, string) => !char.isLetterOrDigit
+        }.mapValues(_.length)
+      })
+    val chars = charMaps.flatMap(map => map.keys).distinct
+
+    val checkSeparatorCondition = (char: Char) => {
+      val counts = charMaps.map(map => map.withDefaultValue(0)(char)).filter(x => x > 0)
+      (counts.forall(_ == counts.head), counts.head, char)
     }
-    result
+    val candidates = chars.map(checkSeparatorCondition).filter{case (valid, counts, char) => valid}
+
+    if (candidates.isEmpty)
+      throw new IllegalArgumentException(s"No possible separator found in column $propertyName")
+    candidates.maxBy{case (valid, counts, char) => counts}._3.toString
   }
 
-  def createSplitValuesDataFrame(dataFrame: Dataset[Row], propertyName: String, separator: String, fromLeft: Boolean, times: Int): Dataset[Row] = {
+  def findNumberOfColumns(dataFrame: Dataset[Row], propertyName: String, separator: String): Int = {
+    // Given a column name, and a separator, this method returns the number of columns that should be
+    // created by a split. This number is the maximum of the number of split parts over all rows.
+
+    val counts = dataFrame.select(propertyName).collect().map(
+      row => {
+        val value = row.getAs[String](0)
+        value.split(separator).length
+      }
+    ).filter(x => x > 1)
+
+    if (counts.isEmpty )
+      throw new IllegalArgumentException(s"Separator not found in column $propertyName")
+    counts.max
+  }
+
+  def createSplitValuesDataFrame(dataFrame: Dataset[Row], propertyName: String, separator: String, times: Int, fromLeft: Boolean): Dataset[Row] = {
     val rowEncoder = RowEncoder(appendEmptyColumns(dataFrame, propertyName, times).schema)
 
     val splitValue = (value: String) => {
@@ -78,36 +122,11 @@ class DefaultSplitPropertyImpl extends PreparatorImpl {
     )(rowEncoder)
   }
 
-  def findMaxSeperatorCount(dataFrame: Dataset[Row], propertyName: String, separator: String): Int = {
-    val counts = dataFrame
-      .select(propertyName)
-      .collect()
-      .map(row => {
-        val operatedValue: String = row.getAs[String](0)
-        operatedValue.split(separator).length
-      })
-    counts.max
-  }
-
-  def findSeperator(dataFrame: Dataset[Row], propertyName: String): String = {
-    val charMaps = dataFrame.select(propertyName).collect().map(row => {
-      val value = row.getAs[String](0)
-      value.groupBy(identity).filter{
-        case(char, string) => !char.isLetterOrDigit
-      }.mapValues(_.length)
-    })
-    val chars = charMaps.flatMap(map => map.keys).distinct
-    val checkSeparatorCondition = (char: Char) => {
-      val counts = charMaps.map(map => map.withDefaultValue(0)(char)).filter(x => x > 0)
-      (counts.forall(_ == counts.head), counts.head, char)
-
+  def appendEmptyColumns(dataFrame: Dataset[Row], propertyName: String, numCols: Int): Dataset[Row] = {
+    var result = dataFrame
+    for (i <- 1 to numCols) {
+      result = result.withColumn(s"$propertyName$i", lit(""))
     }
-    chars.map(checkSeparatorCondition).filter{
-      case (valid, counts, char) => valid
-    }
-    .maxBy{
-      case (valid, counts, char) => counts
-    }._3.toString
-
+    result
   }
 }

--- a/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/implementation/DefaultSplitPropertyImpl.scala
+++ b/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/implementation/DefaultSplitPropertyImpl.scala
@@ -17,12 +17,15 @@ class DefaultSplitPropertyImpl extends PreparatorImpl {
     val propertyName = preparator.propertyName
     val separator = preparator.separator
     val fromLeft = preparator.fromLeft
-    val times = preparator.times
+
 
     if (!dataFrame.columns.contains(propertyName))
       throw new IllegalArgumentException(s"dataFrame has no column $propertyName")
 
-    val bla = findMaxSeperatorCount(dataFrame, propertyName, separator)
+    val times = preparator.times match {
+      case null => findMaxSeperatorCount(dataFrame, propertyName, separator)
+      case Some(t) => t
+    }
 
     if (times < 2)
       return new ExecutionContext(dataFrame, errorAccumulator)
@@ -73,15 +76,15 @@ class DefaultSplitPropertyImpl extends PreparatorImpl {
   }
 
   def findMaxSeperatorCount(dataSet: Dataset[Row], propertyName: String, separator: String): Int = {
-    val test = dataSet
+    val counts = dataSet
       .select(propertyName)
       .collect()
       .map(row => {
         val operatedValue: String = row.getAs[String](0)
-        println("Test")
-        operatedValue.count(_ == separator)
+        operatedValue.split(separator).length
       })
 
-    1
+    counts.max
   }
+
 }

--- a/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/implementation/DefaultSplitPropertyImpl.scala
+++ b/data-prep/dataprep-simple/src/main/scala/de/hpi/isg/dataprep/preparators/implementation/DefaultSplitPropertyImpl.scala
@@ -19,7 +19,7 @@ class DefaultSplitPropertyImpl extends PreparatorImpl {
     val (separator, numCols) = try {
       val separator = preparator.separator match {
         case Some(s) => s
-        case _ => findSeperator(dataFrame, propertyName)
+        case _ => findSeparator(dataFrame, propertyName)
       }
 
       val numCols = preparator.numCols match {
@@ -46,7 +46,7 @@ class DefaultSplitPropertyImpl extends PreparatorImpl {
     new ExecutionContext(splitValuesDataFrame, errorAccumulator)
   }
 
-  def findSeperator(dataFrame: Dataset[Row], propertyName: String): String = {
+  def findSeparator(dataFrame: Dataset[Row], propertyName: String): String = {
     // Given a column name, this method returns the character that is most likely the separator.
     // Possible separators are non-alphanumeric characters that are evenly distributed over all rows.
     // Rows where the character does not appear at all are ignored.
@@ -86,7 +86,7 @@ class DefaultSplitPropertyImpl extends PreparatorImpl {
       }
     ).filter(x => x > 1)
 
-    if (counts.isEmpty )
+    if (counts.isEmpty)
       throw new IllegalArgumentException(s"Separator not found in column $propertyName")
     counts.max
   }

--- a/data-prep/dataprep-simple/src/test/java/de/hpi/isg/dataprep/preparators/PaddingTest.java
+++ b/data-prep/dataprep-simple/src/test/java/de/hpi/isg/dataprep/preparators/PaddingTest.java
@@ -10,6 +10,8 @@ import de.hpi.isg.dataprep.model.target.errorlog.PipelineErrorLog;
 import de.hpi.isg.dataprep.model.target.errorlog.PreparationErrorLog;
 import de.hpi.isg.dataprep.model.target.system.AbstractPreparation;
 import de.hpi.isg.dataprep.util.DataType;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -25,50 +27,15 @@ public class PaddingTest extends PreparatorTest {
     @Test
     public void testPaddingAllShorterValue() throws Exception {
         Preparator preparator = new Padding("id", 8);
-
         AbstractPreparation preparation = new Preparation(preparator);
         pipeline.addPreparation(preparation);
         pipeline.executePipeline();
 
-        List<ErrorLog> trueErrorlogs = new ArrayList<>();
-//        ErrorLog pipelineError1 = new PipelineErrorLog(pipeline,
-//                new MetadataNotFoundException(String.format("The metadata %s not found in the repository.", "PropertyDataType{" +
-//                        "propertyName='" + "id" + '\'' +
-//                        ", propertyDataType=" + DataType.PropertyType.STRING.toString() +
-//                        '}')));
-//        trueErrorlogs.add(pipelineError1);
-        ErrorRepository trueErrorRepository = new ErrorRepository(trueErrorlogs);
-
         pipeline.getRawData().show();
 
-        Assert.assertEquals(trueErrorRepository, pipeline.getErrorRepository());
-    }
-
-    @Test
-    public void testPaddingValueTooLong() throws Exception {
-        Preparator preparator = new Padding("id", 4, "x");
-
-        AbstractPreparation preparation = new Preparation(preparator);
-        pipeline.addPreparation(preparation);
-        pipeline.executePipeline();
-
-        List<ErrorLog> trueErrorlogs = new ArrayList<>();
-//        ErrorLog pipelineError1 = new PipelineErrorLog(pipeline,
-//                new MetadataNotFoundException(String.format("The metadata %s not found in the repository.", "PropertyDataType{" +
-//                        "propertyName='" + "id" + '\'' +
-//                        ", propertyDataType=" + DataType.PropertyType.STRING.toString() +
-//                        '}')));
-//        trueErrorlogs.add(pipelineError1);
-
-        ErrorLog errorlog1 = new PreparationErrorLog(preparation, "three",
-                new IllegalArgumentException(String.format("Value length is already larger than padded length.")));
-        trueErrorlogs.add(errorlog1);
-
-        ErrorRepository trueErrorRepository = new ErrorRepository(trueErrorlogs);
-
-        pipeline.getRawData().show();
-
-        Assert.assertEquals(trueErrorRepository, pipeline.getErrorRepository());
-        Assert.assertEquals(pipeline.getRawData().count(), 9L);
+        Assert.assertEquals(
+                new ErrorRepository(new ArrayList<>()),
+                pipeline.getErrorRepository()
+        );
     }
 }

--- a/data-prep/dataprep-simple/src/test/java/de/hpi/isg/dataprep/preparators/PaddingTest.java
+++ b/data-prep/dataprep-simple/src/test/java/de/hpi/isg/dataprep/preparators/PaddingTest.java
@@ -10,8 +10,6 @@ import de.hpi.isg.dataprep.model.target.errorlog.PipelineErrorLog;
 import de.hpi.isg.dataprep.model.target.errorlog.PreparationErrorLog;
 import de.hpi.isg.dataprep.model.target.system.AbstractPreparation;
 import de.hpi.isg.dataprep.util.DataType;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -27,15 +25,50 @@ public class PaddingTest extends PreparatorTest {
     @Test
     public void testPaddingAllShorterValue() throws Exception {
         Preparator preparator = new Padding("id", 8);
+
         AbstractPreparation preparation = new Preparation(preparator);
         pipeline.addPreparation(preparation);
         pipeline.executePipeline();
 
+        List<ErrorLog> trueErrorlogs = new ArrayList<>();
+//        ErrorLog pipelineError1 = new PipelineErrorLog(pipeline,
+//                new MetadataNotFoundException(String.format("The metadata %s not found in the repository.", "PropertyDataType{" +
+//                        "propertyName='" + "id" + '\'' +
+//                        ", propertyDataType=" + DataType.PropertyType.STRING.toString() +
+//                        '}')));
+//        trueErrorlogs.add(pipelineError1);
+        ErrorRepository trueErrorRepository = new ErrorRepository(trueErrorlogs);
+
         pipeline.getRawData().show();
 
-        Assert.assertEquals(
-                new ErrorRepository(new ArrayList<>()),
-                pipeline.getErrorRepository()
-        );
+        Assert.assertEquals(trueErrorRepository, pipeline.getErrorRepository());
+    }
+
+    @Test
+    public void testPaddingValueTooLong() throws Exception {
+        Preparator preparator = new Padding("id", 4, "x");
+
+        AbstractPreparation preparation = new Preparation(preparator);
+        pipeline.addPreparation(preparation);
+        pipeline.executePipeline();
+
+        List<ErrorLog> trueErrorlogs = new ArrayList<>();
+//        ErrorLog pipelineError1 = new PipelineErrorLog(pipeline,
+//                new MetadataNotFoundException(String.format("The metadata %s not found in the repository.", "PropertyDataType{" +
+//                        "propertyName='" + "id" + '\'' +
+//                        ", propertyDataType=" + DataType.PropertyType.STRING.toString() +
+//                        '}')));
+//        trueErrorlogs.add(pipelineError1);
+
+        ErrorLog errorlog1 = new PreparationErrorLog(preparation, "three",
+                new IllegalArgumentException(String.format("Value length is already larger than padded length.")));
+        trueErrorlogs.add(errorlog1);
+
+        ErrorRepository trueErrorRepository = new ErrorRepository(trueErrorlogs);
+
+        pipeline.getRawData().show();
+
+        Assert.assertEquals(trueErrorRepository, pipeline.getErrorRepository());
+        Assert.assertEquals(pipeline.getRawData().count(), 9L);
     }
 }

--- a/data-prep/dataprep-simple/src/test/java/de/hpi/isg/dataprep/preparators/SplitPropertyTest.java
+++ b/data-prep/dataprep-simple/src/test/java/de/hpi/isg/dataprep/preparators/SplitPropertyTest.java
@@ -22,24 +22,13 @@ public class SplitPropertyTest extends PreparatorTest {
 
     @Test
     public void testPaddingAllShorterValue() throws Exception {
-        Preparator preparator = new SplitProperty("date", null, true, null);
+        Preparator preparator = new SplitProperty("date");
 
-        AbstractPreparation preparation = new Preparation(preparator);
-        pipeline.addPreparation(preparation);
+        pipeline.addPreparation(new Preparation(preparator));
         pipeline.executePipeline();
-
-        List<ErrorLog> trueErrorlogs = new ArrayList<>();
-//        ErrorLog pipelineError1 = new PipelineErrorLog(pipeline,
-//                new MetadataNotFoundException(String.format("The metadata %s not found in the repository.", "PropertyDataType{" +
-//                        "propertyName='" + "id" + '\'' +
-//                        ", propertyDataType=" + DataType.PropertyType.STRING.toString() +
-//                        '}')));
-//        trueErrorlogs.add(pipelineError1);
-        ErrorRepository trueErrorRepository = new ErrorRepository(trueErrorlogs);
-
         pipeline.getRawData().show();
 
-        Assert.assertEquals(trueErrorRepository, pipeline.getErrorRepository());
+        Assert.assertEquals(new ErrorRepository(new ArrayList<>()), pipeline.getErrorRepository());
     }
 
     @Test

--- a/data-prep/dataprep-simple/src/test/java/de/hpi/isg/dataprep/preparators/SplitPropertyTest.java
+++ b/data-prep/dataprep-simple/src/test/java/de/hpi/isg/dataprep/preparators/SplitPropertyTest.java
@@ -106,4 +106,18 @@ public class SplitPropertyTest extends PreparatorTest {
                 }
         );
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIllegalArgumentExceptionWhenNumColsIs1() throws Exception {
+        Preparator preparator = new SplitProperty("date", "-", 1, true);
+        pipeline.addPreparation(new Preparation(preparator));
+        pipeline.executePipeline();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIllegalArgumentExceptionWhenPropertyNameDoNotExist() throws Exception {
+        Preparator preparator = new SplitProperty("xyz", "-", 3, true);
+        pipeline.addPreparation(new Preparation(preparator));
+        pipeline.executePipeline();
+    }
 }

--- a/data-prep/dataprep-simple/src/test/java/de/hpi/isg/dataprep/preparators/SplitPropertyTest.java
+++ b/data-prep/dataprep-simple/src/test/java/de/hpi/isg/dataprep/preparators/SplitPropertyTest.java
@@ -22,7 +22,7 @@ public class SplitPropertyTest extends PreparatorTest {
 
     @Test
     public void testPaddingAllShorterValue() throws Exception {
-        Preparator preparator = new SplitProperty("date", "-", true, null);
+        Preparator preparator = new SplitProperty("date", null, true, null);
 
         AbstractPreparation preparation = new Preparation(preparator);
         pipeline.addPreparation(preparation);

--- a/data-prep/dataprep-simple/src/test/java/de/hpi/isg/dataprep/preparators/SplitPropertyTest.java
+++ b/data-prep/dataprep-simple/src/test/java/de/hpi/isg/dataprep/preparators/SplitPropertyTest.java
@@ -53,19 +53,15 @@ public class SplitPropertyTest extends PreparatorTest {
 
         pipeline.getRawData().foreach(
                 row -> {
-                    String date = row.get(8).toString();
-                    String[] split = date.split("-");
-                    if(split.length > 1) {
-                        String date1 = row.get(9).toString();
-                        String date2 = row.get(10).toString();
-                        String date3 = row.get(11).toString();
-                        Assert.assertEquals(split[0], date1);
-                        Assert.assertEquals(split[1], date2);
-                        Assert.assertEquals(split[2], date3);
+                    String[] expectedSplit = row.get(8).toString().split("-");
+                    String[] split = {row.get(9).toString(), row.get(10).toString(), row.get(11).toString()};
+                    if(expectedSplit.length == 1) {
+                        String[] singleValueSplit = {expectedSplit[0], "", ""};
+                        Assert.assertArrayEquals(singleValueSplit, split);
+                    } else {
+                        Assert.assertArrayEquals(expectedSplit, split);
                     }
                 }
         );
-
-
     }
 }

--- a/data-prep/dataprep-simple/src/test/java/de/hpi/isg/dataprep/preparators/SplitPropertyTest.java
+++ b/data-prep/dataprep-simple/src/test/java/de/hpi/isg/dataprep/preparators/SplitPropertyTest.java
@@ -1,0 +1,72 @@
+package de.hpi.isg.dataprep.preparators;
+
+import de.hpi.isg.dataprep.components.Preparation;
+import de.hpi.isg.dataprep.components.Preparator;
+import de.hpi.isg.dataprep.model.repository.ErrorRepository;
+import de.hpi.isg.dataprep.model.target.errorlog.ErrorLog;
+import de.hpi.isg.dataprep.model.target.errorlog.PreparationErrorLog;
+import de.hpi.isg.dataprep.model.target.system.AbstractPreparation;
+import de.hpi.isg.dataprep.preparators.define.Padding;
+import de.hpi.isg.dataprep.preparators.define.SplitProperty;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Lan Jiang
+ * @since 2018/8/29
+ */
+public class SplitPropertyTest extends PreparatorTest {
+
+    @Test
+    public void testPaddingAllShorterValue() throws Exception {
+        Preparator preparator = new SplitProperty("date", '-', true, 2);
+
+        AbstractPreparation preparation = new Preparation(preparator);
+        pipeline.addPreparation(preparation);
+        pipeline.executePipeline();
+
+        List<ErrorLog> trueErrorlogs = new ArrayList<>();
+//        ErrorLog pipelineError1 = new PipelineErrorLog(pipeline,
+//                new MetadataNotFoundException(String.format("The metadata %s not found in the repository.", "PropertyDataType{" +
+//                        "propertyName='" + "id" + '\'' +
+//                        ", propertyDataType=" + DataType.PropertyType.STRING.toString() +
+//                        '}')));
+//        trueErrorlogs.add(pipelineError1);
+        ErrorRepository trueErrorRepository = new ErrorRepository(trueErrorlogs);
+
+        pipeline.getRawData().show();
+
+        Assert.assertEquals(trueErrorRepository, pipeline.getErrorRepository());
+    }
+
+    @Test
+    public void testPaddingValueTooLong() throws Exception {
+        Preparator preparator = new Padding("id", 4, "x");
+
+        AbstractPreparation preparation = new Preparation(preparator);
+        pipeline.addPreparation(preparation);
+        pipeline.executePipeline();
+
+        List<ErrorLog> trueErrorlogs = new ArrayList<>();
+//        ErrorLog pipelineError1 = new PipelineErrorLog(pipeline,
+//                new MetadataNotFoundException(String.format("The metadata %s not found in the repository.", "PropertyDataType{" +
+//                        "propertyName='" + "id" + '\'' +
+//                        ", propertyDataType=" + DataType.PropertyType.STRING.toString() +
+//                        '}')));
+//        trueErrorlogs.add(pipelineError1);
+
+        ErrorLog errorlog1 = new PreparationErrorLog(preparation, "three",
+                new IllegalArgumentException(String.format("Value length is already larger than padded length.")));
+        trueErrorlogs.add(errorlog1);
+
+        ErrorRepository trueErrorRepository = new ErrorRepository(trueErrorlogs);
+
+        pipeline.getRawData().show();
+
+        Assert.assertEquals(trueErrorRepository, pipeline.getErrorRepository());
+        Assert.assertEquals(pipeline.getRawData().count(), 9L);
+    }
+}

--- a/data-prep/dataprep-simple/src/test/java/de/hpi/isg/dataprep/preparators/SplitPropertyTest.java
+++ b/data-prep/dataprep-simple/src/test/java/de/hpi/isg/dataprep/preparators/SplitPropertyTest.java
@@ -22,7 +22,7 @@ public class SplitPropertyTest extends PreparatorTest {
 
     @Test
     public void testPaddingAllShorterValue() throws Exception {
-        Preparator preparator = new SplitProperty("date", "-", true, 2);
+        Preparator preparator = new SplitProperty("date", "-", true, null);
 
         AbstractPreparation preparation = new Preparation(preparator);
         pipeline.addPreparation(preparation);

--- a/data-prep/dataprep-simple/src/test/java/de/hpi/isg/dataprep/preparators/SplitPropertyTest.java
+++ b/data-prep/dataprep-simple/src/test/java/de/hpi/isg/dataprep/preparators/SplitPropertyTest.java
@@ -22,7 +22,7 @@ public class SplitPropertyTest extends PreparatorTest {
 
     @Test
     public void testPaddingAllShorterValue() throws Exception {
-        Preparator preparator = new SplitProperty("date", '-', true, 2);
+        Preparator preparator = new SplitProperty("date", "-", true, 2);
 
         AbstractPreparation preparation = new Preparation(preparator);
         pipeline.addPreparation(preparation);


### PR DESCRIPTION
A new preparator is added to the project: `SplitProperty`
This preparator splits the content of a column into multiple columns. 
If instantiated with the name of a column, it uses some heuristics to determine the separator.
Alternatively, the separator, the number of new columns, and the direction of the split (left or right) can be defined explicitly.

```
SplitProperty(propertyName: String)
SplitProperty(propertyName: String, separator: String)
SplitProperty(propertyName: String, separator: String, numCols: Int, fromLeft: Boolean)
```
_by Hao Nguyen & Jakob Köhler_