### PR TITLE
Fix failing ChangeTableEncoding test by pinning the Guava dependency to 16

### DIFF
--- a/data-prep/dataprep-simple/pom.xml
+++ b/data-prep/dataprep-simple/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
-            <version>0.9.11</version>
+            <version>0.9.10</version>
         </dependency>
     </dependencies>
 

--- a/data-prep/dataprep-simple/src/test/java/de/hpi/isg/dataprep/preparators/ChangeTableEncodingTest.java
+++ b/data-prep/dataprep-simple/src/test/java/de/hpi/isg/dataprep/preparators/ChangeTableEncodingTest.java
@@ -112,11 +112,6 @@ public class ChangeTableEncodingTest {
         pipeline.executePipeline();
     }
 
-    /**
-     * This test does not pass, because reloading dataset operation complains about "IllegalAccessError: tried to access method com.google.common.base.Stopwatch"
-     * @throws Exception
-     */
-    @Ignore
     @Test
     public void testWrongEncodingInCSV() throws Exception {
         DataContext context = load(ERRORS_URL);

--- a/data-prep/pom.xml
+++ b/data-prep/pom.xml
@@ -182,6 +182,12 @@
             <artifactId>juniversalchardet</artifactId>
             <version>1.0.3</version>
         </dependency>
+        <!-- pin Guava dependency -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>16.0.1</version>
+        </dependency>
         <dependency>
             <groupId>org.nd4j</groupId>
             <artifactId>nd4j-native-platform</artifactId>

--- a/data-prep/pom.xml
+++ b/data-prep/pom.xml
@@ -182,7 +182,8 @@
             <artifactId>juniversalchardet</artifactId>
             <version>1.0.3</version>
         </dependency>
-        <!-- pin Guava dependency -->
+        <!-- pin Guava dependency - This is a temporary fix! -->
+        <!-- When a Spark version that depends on Guava 17 or later is released, consider using that version and removing this Guava dependency-->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>


### PR DESCRIPTION
This fix is far from ideal, as our dependency `deeplearning4j` depends on Guava 20, but since it doesn't break any tests it should work as a temporary solution.