### PR TITLE
Use URIs instead of URLs to handle file paths containing spaces

### DIFF
--- a/data-prep/dataprep-model/src/main/scala/de/hpi/isg/dataprep/DateScorer.scala
+++ b/data-prep/dataprep-model/src/main/scala/de/hpi/isg/dataprep/DateScorer.scala
@@ -1,6 +1,6 @@
 package de.hpi.isg.dataprep
 
-import java.net.URL
+import java.net.URI
 
 import org.deeplearning4j.nn.modelimport.keras.KerasModelImport
 import org.deeplearning4j.nn.multilayer.MultiLayerNetwork
@@ -61,15 +61,15 @@ class DateScorer(modelFile: String = "model.hdf5", vocabularyFile: String = "voc
     * Wrapper method that uses the vocabulary file specified at object creation.
     */
   def loadVocabulary(): Unit = {
-    loadVocabulary(getClass.getResource(s"/date_format/$vocabularyFile"))
+    loadVocabulary(getClass.getResource(s"/date_format/$vocabularyFile").toURI)
   }
 
   /**
     * Loads a CSV vocabulary file in the format "index,token".
     * @param path URL to the vocabulary file
     */
-  def loadVocabulary(path: URL): Unit = {
-    val file = Source.fromURL(path)
+  def loadVocabulary(path: URI): Unit = {
+    val file = Source.fromURI(path)
     vocabulary = file
         .getLines()
         .map { line =>
@@ -82,14 +82,14 @@ class DateScorer(modelFile: String = "model.hdf5", vocabularyFile: String = "voc
     * Wrapper method that uses the model file specified at object creation.
     */
   def loadModel(): Unit = {
-    loadModel(getClass.getResource(s"/date_format/$modelFile"))
+    loadModel(getClass.getResource(s"/date_format/$modelFile").toURI)
   }
 
   /**
     * Loads a Sequential Keras model (hdf5) with DL4J.
     * @param path URL to the model file
     */
-  def loadModel(path: URL): Unit = {
+  def loadModel(path: URI): Unit = {
     // since we only predict we don't need a training config
     model = KerasModelImport.importKerasSequentialModelAndWeights(path.getPath, false)
   }

--- a/data-prep/dataprep-model/src/test/scala/de/hpi/isg/dataprep/DateScorerTest.scala
+++ b/data-prep/dataprep-model/src/test/scala/de/hpi/isg/dataprep/DateScorerTest.scala
@@ -17,7 +17,7 @@ class DateScorerTest extends FlatSpecLike with Matchers {
     val scorer = new DateScorer()
     scorer.vocabulary should not be empty
     val oldSize = scorer.vocabulary.size
-    scorer.loadVocabulary(getClass.getResource(s"/date_format/$testVocabulary"))
+    scorer.loadVocabulary(getClass.getResource(s"/date_format/$testVocabulary").toURI)
     scorer.vocabulary should not be empty
     scorer.vocabulary.size should not equal oldSize
   }
@@ -25,13 +25,13 @@ class DateScorerTest extends FlatSpecLike with Matchers {
   it should "use the correct oov index" in {
     val scorer = new DateScorer()
     scorer.oovTokenIndex() shouldEqual 0
-    scorer.loadVocabulary(getClass.getResource(s"/date_format/$testVocabulary"))
+    scorer.loadVocabulary(getClass.getResource(s"/date_format/$testVocabulary").toURI)
     scorer.oovTokenIndex() shouldEqual 1
   }
 
   it should "tokenize strings" in {
     val scorer = new DateScorer()
-    scorer.loadVocabulary(getClass.getResource(s"/date_format/$testVocabulary"))
+    scorer.loadVocabulary(getClass.getResource(s"/date_format/$testVocabulary").toURI)
     val input = "$%&%%&&"
     val tokens = scorer.tokenize(input)
     tokens shouldEqual List(5, 6, 7, 6, 6, 7, 7)
@@ -45,7 +45,7 @@ class DateScorerTest extends FlatSpecLike with Matchers {
     var tokens = scorer.tokenize(input)
     tokens shouldEqual List(5, 66, 67, 68, 0)
 
-    scorer.loadVocabulary(getClass.getResource(s"/date_format/$testVocabulary"))
+    scorer.loadVocabulary(getClass.getResource(s"/date_format/$testVocabulary").toURI)
     tokens = scorer.tokenize(input)
     // now the oov token is 1
     tokens shouldEqual List(5, 1, 1, 1, 1)

--- a/data-prep/dataprep-simple/src/test/scala/de/hpi/isg/dataprep/preparators/PreparatorScalaTest.scala
+++ b/data-prep/dataprep-simple/src/test/scala/de/hpi/isg/dataprep/preparators/PreparatorScalaTest.scala
@@ -21,7 +21,7 @@ trait PreparatorScalaTest extends FlatSpecLike with Matchers with BeforeAndAfter
     Logger.getLogger("org").setLevel(Level.OFF)
     Logger.getLogger("akka").setLevel(Level.OFF)
 
-    val filePath = getClass.getResource(resourcePath).getPath
+    val filePath = getClass.getResource(resourcePath).toURI.getPath
     val dialect = new DialectBuilder()
       .hasHeader(true)
       .inferSchema(true)

--- a/data-prep/dataprep-simple/src/test/scala/de/hpi/isg/dataprep/preparators/RemovePreamble.scala
+++ b/data-prep/dataprep-simple/src/test/scala/de/hpi/isg/dataprep/preparators/RemovePreamble.scala
@@ -63,11 +63,11 @@ class RemovePreamble extends PreparatorScalaTest {
     val localContext = sparkContext
     val customDataset = localContext.read
       .option("sep", "\t")
-            .csv(getClass.getClassLoader.getResource("preamble_initial_char_fail.csv").toString)
+            .csv(getClass.getClassLoader.getResource("preamble_initial_char_fail.csv").toURI.getPath)
 
     val expectedDataset = localContext.read
       .option("sep", "\t")
-            .csv(getClass.getClassLoader.getResource("preamble_initial_char_fail_expected.csv").toString)
+            .csv(getClass.getClassLoader.getResource("preamble_initial_char_fail_expected.csv").toURI.getPath)
 
     val prep = new DefaultRemovePreambleImpl
     val result = prep.analyseLeadingCharacter(customDataset)
@@ -81,11 +81,11 @@ class RemovePreamble extends PreparatorScalaTest {
     val localContext = sparkContext
     val customDataset = localContext.read
       .option("sep", "\t")
-            .csv(getClass.getClassLoader.getResource("preamble_initial_char_space_fail.csv").toString)
+            .csv(getClass.getClassLoader.getResource("preamble_initial_char_space_fail.csv").toURI.getPath)
 
     val expectedDataset = localContext.read
       .option("sep", "\t")
-            .csv(getClass.getClassLoader.getResource("preamble_initial_char_space_fail_expected.csv").toString)
+            .csv(getClass.getClassLoader.getResource("preamble_initial_char_space_fail_expected.csv").toURI.getPath)
 
     val prep = new DefaultRemovePreambleImpl
     val result = prep.analyseLeadingCharacter(customDataset)


### PR DESCRIPTION
The `Class.getResource` method returns the URL to a file. The URL corresponds to the file path, except any space character in the file path is converted to `%20`. To get the original file path, the URL first needs to be converted to a URI.